### PR TITLE
Typo and style fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,58 +2,58 @@ SilverSprints - [http://SilverSprints.com](http://silversprints.com)
 =============
 A front end for the [OpenSprints](https://www.opensprints.com) hardware kit.  It allows for the racing of 1 to 4 bikers against each other in a goldsprints style race.  The software is free to use and modify and you're encouraged to hold your own races!  See _LICENSE_ for more details.
 
-[SilverSprints](http://silversprints.com/) is for OSX (10.7 and up) and Windows (7 and up).
+[SilverSprints](http://silversprints.com/) is for OS X (10.7 and up) and Windows (7 and up).
 
 Written in [Cinder](https://libcinder.org/), an opensource C++ library for creative coding.
 
 ## Using the Application
 
 #### Requirements
-* Requires OXS version 10.7 and up.
-* PC requires Windows 7 and up
+* Requires OS X version 10.7 and up.
+* PC requires Windows 7 and up.
 
 #### Installation
 1. Download the latest [SilverSprints](https://github.com/cwhitney/SilverSprint/releases/latest) for your operating system.
-2. In the downlaoded zip file, there is an `Arduino` folder with software you'll need to load onto the OpenSprints hardware.  Detailed instructions on how to do this can be found here: [http://cwhitney.github.io/SilverSprint/installation.html](http://cwhitney.github.io/SilverSprint/installation.html)
+2. In the downlaoded zip file, there is an `Arduino` folder with software you'll need to load onto the OpenSprints hardware.  Detailed instructions on how to do this can be found here: [http://cwhitney.github.io/SilverSprint/installation.html](http://cwhitney.github.io/SilverSprint/installation.html).
  
 #### App Settings
-1. Go to the Settings page by clicking the gear icon or pressing Command + 3
+1. Go to the Settings page by clicking the gear icon or pressing Command + 3.
 2. Set the roller diameter as the distance from the magnet to the center of the roller multiplied by 2.
-3. Choose the number of racers competing from 1-4
-4. If SilverSprint detects an Arduino connected it will show a checkmark, otherwise it will display an X.
+3. Choose the number of racers competing from 1-4.
+4. If SilverSprints detects an Arduino connected it will show a checkmark, otherwise it will display an X.
 
 #### Roster
-1. Go to the Roster page by clicking the list icon or pressing Command + 2
-2. Set all active participants names
+1. Go to the Roster page by clicking the list icon or pressing Command + 2.
+2. Set all active participants' names.
 
 #### Race
-1. Click the START button to begin a race
+1. Click the START button to begin a race.
 2. At any time, press STOP to stop and reset the race.
 
 ## Editing / Creating New Graphics
 If you just want to swap graphics, simply replace the graphics in the assets folder. No need to recompile.
 
 ## Troubleshooting
-In the event of a crash, a log file will be created in a folder called "logs" in the SilverSprint directory.
+In the event of a crash, a log file will be created in a folder called "logs" in the SilverSprints directory.
 Please attach this file when asking for support along with any other relevant information.
 
 ## Code Setup
-1. Clone the repo with all of it's sumodules with: `git clone https://github.com/cwhitney/SilverSprint.git --depth 1 --recursive`
-1. Build Cinder for your platform [OSX](https://libcinder.org/docs/guides/mac-setup/index.html) - [Windows](https://libcinder.org/docs/guides/windows-setup/index.html).
-If you're having trouble building Cinder, it may be missing some of it's dependencies.  You may need to run `git submodule update --init --recursive` to make sure Cinder has all of it's submodules.
-2. The structure of the repo is like so:  
+1. Clone the repo with all of its submodules with: `git clone https://github.com/cwhitney/SilverSprint.git --depth 1 --recursive`
+2. Build Cinder for your platform [OS X](https://libcinder.org/docs/guides/mac-setup/index.html) - [Windows](https://libcinder.org/docs/guides/windows-setup/index.html).
+If you're having trouble building Cinder, it may be missing some of its dependencies.  You may need to run `git submodule update --init --recursive` to make sure Cinder has all of its submodules.
+3. The structure of the repo is like so:  
 
 ```
 Root	
   - apps  
     - Arduino
-    - SilverSprint
+    - SilverSprints
   - libs
     - Cinder
 ```
-3. Update Arduino if necessary. (See above)
-4. Open the project file for your platform. It will be in `apps/SilverSprint/xcode/SilverSprint.xcodeproj` for OSX, and `appsSilverSprint/vs2015` for PC.
-5. Build Silversprints. There are no external dependencies aside from Cinder itself.
+4. Update Arduino if necessary. (See above.)
+5. Open the project file for your platform. It will be in `apps/SilverSprints/xcode/SilverSprint.xcodeproj` for OS X, and `apps/SilverSprints/vs2015` for PC.
+6. Build SilverSprints. There are no external dependencies aside from Cinder itself.
 
 ## Credits
 


### PR DESCRIPTION
Just a couple suggested typo and style tweaks to the README.

* Consistently spell "SilverSprints" with an internal capital "S" and a final "s"
  * including when mentioning the `apps/SilverSprints` directory, which is spelled that way in the repo structure
* Fix "OXS" and "sumodules" typo
* Style "OS X" with a space, matching Apple's styling
* Consistently end parallel list items with a period
* Fix the numbering on the split list under "Code Setup" (it currently has a duplicate item "3." when rendered)
* Possessive "its" does not have an apostrophe