### PR TITLE
Linux Port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib/msw/x86/cinder*.pdb
 lib/msw/x64/cinder*.pdb
 lib/winrt/x86/cinder*.lib
 lib/winrt/x64/cinder*.lib
+apps/Silversprints/build/
 
 # Windows cruft
 *.suo

--- a/apps/Silversprints/CMakeLists.txt
+++ b/apps/Silversprints/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.10)
+project(SilverSprint)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Define o caminho do Cinder (user-defined)
+set(CINDER_PATH "" CACHE PATH "Path to Cinder root directory.")
+if(NOT CINDER_PATH)
+    message(FATAL_ERROR "CINDER_PATH not defined. Please specify the path to your Cinder installation.")
+endif()
+
+
+# Encontre as bibliotecas do sistema (X11, cURL, Fontconfig)
+find_package(X11 REQUIRED)
+find_package(CURL REQUIRED)
+find_package(Fontconfig REQUIRED)
+
+# Include directories
+include_directories(
+    ${CINDER_PATH}/include
+    include
+    blocks/OSC/src
+    blocks/Serial/include
+    blocks/Serial/lib/serial/include
+    blocks/Sharkbox
+    ../SilverSprints/blocks/Sharkbox
+    ../SilverSprints/include
+    blocks/Serial/lib/serial/include/serial/
+    blocks/ParticleSystem
+)
+
+# Fontes principais
+file(GLOB APP_SRC
+    src/app/*.cpp
+    src/data/*.cpp
+    src/ui/*.cpp
+    src/views/*.cpp
+    ../SilverSprints/src/*.cpp
+    ../SilverSprints/src/ui/*.cpp
+)
+
+# Fontes dos blocks
+set(BLOCK_SRC
+    blocks/OSC/src/cinder/osc/Osc.cpp
+    blocks/ParticleSystem/ParticleSystem.cpp
+    blocks/Serial/src/SerialDevice.cpp
+    blocks/Serial/lib/serial/src/serial.cc
+    blocks/Serial/lib/serial/src/impl/unix.cc
+    blocks/Serial/lib/serial/src/impl/list_ports/list_ports_linux.cc
+)
+
+# Junta tudo
+add_executable(${PROJECT_NAME}
+    ${APP_SRC}
+    ${BLOCK_SRC}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    # As bibliotecas do Cinder
+    ${CINDER_LIBRARIES}
+    /home/gabs/dev/rolofest/Cinder/lib/linux/x86_64/ogl/Release/libcinder.a
+
+    # Bibliotecas do sistema Linux
+    ${X11_LIBRARIES}
+    ${X11_Xrandr_LIB}
+    ${X11_Xinerama_LIB}
+    ${X11_Xcursor_LIB}
+    
+    # Outras bibliotecas
+    ${CURL_LIBRARIES}
+    ${Fontconfig_LIBRARIES}
+    ${Boost_LIBRARIES}
+    X11
+)

--- a/apps/Silversprints/blocks/OSC/src/cinder/osc/Osc.cpp
+++ b/apps/Silversprints/blocks/OSC/src/cinder/osc/Osc.cpp
@@ -1525,7 +1525,9 @@ void ReceiverTcp::accept( OnAcceptErrorFn onAcceptErrorFn, OnAcceptFn onAcceptFn
 	if( ! mAcceptor || ! mAcceptor->is_open() )
 		return;
 	
-	auto socket = std::make_shared<tcp::socket>( mAcceptor->get_io_service() );
+	//auto socket = std::make_shared<tcp::socket>( mAcceptor->get_io_service() );
+	auto socket = std::make_shared<tcp::socket>( mAcceptor->get_executor().context());
+
 	
 	mAcceptor->async_accept( *socket, std::bind(
 	[&, onAcceptErrorFn, onAcceptFn]( TcpSocketRef socket, const asio::error_code &error ) {

--- a/apps/Silversprints/blocks/OSC/src/cinder/osc/Osc.h
+++ b/apps/Silversprints/blocks/OSC/src/cinder/osc/Osc.h
@@ -499,14 +499,14 @@ class SenderUdp : public SenderBase {
 			   const std::string &destinationHost,
 			   uint16_t destinationPort,
 			   const protocol &protocol = protocol::v4(),
-			   asio::io_service &service = ci::app::App::get()->io_service() );
+			   asio::io_service &service = ci::app::App::get()->io_context() );
 	//! Constructs a Sender (called a \a server in the OSC spec) using UDP as transport, whose local endpoint is
 	//! defined by \a localPort and \a protocol, which defaults to v4, and remote endpoint is defined by \a
 	//! destination. Takes an optional io_service, used to construct the socket from.
 	SenderUdp( uint16_t localPort,
 			   const protocol::endpoint &destination,
 			   const protocol &protocol = protocol::v4(),
-			   asio::io_service &service = ci::app::App::get()->io_service() );
+			   asio::io_service &service = ci::app::App::get()->io_context() );
 	//! Constructs a Sender (called a \a server in the OSC spec) using UDP for transport, with an already created
 	//! udp::socket shared_ptr \a socket and remote endpoint \a destination. This constructor is good for using
 	//! already constructed sockets for more indepth configuration. Expects the local endpoint to be constructed.
@@ -562,7 +562,7 @@ class SenderTcp : public SenderBase {
 			   const std::string &destinationHost,
 			   uint16_t destinationPort,
 			   const protocol &protocol = protocol::v4(),
-			   asio::io_service &service = ci::app::App::get()->io_service(),
+			   asio::io_service &service = ci::app::App::get()->io_context(),
 			   PacketFramingRef packetFraming = nullptr );
 	//! Constructs a Sender (called a \a server in the OSC spec) using TCP as transport, whose local endpoint is
 	//! defined by \a localPort and \a protocol, which defaults to v4, and remote endpoint is defined by \a
@@ -571,7 +571,7 @@ class SenderTcp : public SenderBase {
 	SenderTcp( uint16_t localPort,
 			   const protocol::endpoint &destination,
 			   const protocol &protocol = protocol::v4(),
-			   asio::io_service &service = ci::app::App::get()->io_service(),
+			   asio::io_service &service = ci::app::App::get()->io_context(),
 			   PacketFramingRef packetFraming = nullptr );
 	//! Constructs a Sender (called a \a server in the OSC spec) using TCP as transport, with an already created
 	//! tcp::socket shared_ptr \a socket, and remote endpoint is defined by \a destination and PacketFraming
@@ -690,11 +690,11 @@ class ReceiverUdp : public ReceiverBase {
 	//! construct the socket from.
 	ReceiverUdp( uint16_t port,
 				 const protocol &protocol = protocol::v4(),
-				 asio::io_service &io = ci::app::App::get()->io_service()  );
+				 asio::io_service &io = ci::app::App::get()->io_context()  );
 	//! Constructs a Receiver (called a \a client in the OSC spec) using UDP for transport, whose local endpoint
 	//! is defined by \a localEndpoint. Takes an optional io_service to construct the socket from.
 	ReceiverUdp( const protocol::endpoint &localEndpoint,
-				 asio::io_service &io = ci::app::App::get()->io_service() );
+				 asio::io_service &io = ci::app::App::get()->io_context() );
 	//! Constructs a Receiver (called a \a client in the OSC spec) using UDP for transport, from the already
 	//! constructed udp::socket shared_ptr \a socket. Use this for extra configuration and or sharing sockets
 	//! between sender and receiver.
@@ -762,13 +762,13 @@ class ReceiverTcp : public ReceiverBase {
 	//! to construct the socket from.
 	ReceiverTcp( uint16_t port,
 				 const protocol &protocol = protocol::v4(),
-				 asio::io_service &service = ci::app::App::get()->io_service(),
+				 asio::io_service &service = ci::app::App::get()->io_context(),
 				 PacketFramingRef packetFraming = nullptr );
 	//! Constructs a Receiver (called a \a client in the OSC spec) using TCP for transport, whose local endpoint
 	//! is defined by \a localEndpoint and PacketFraming shared_ptr \a packetFraming, which defaults to null. Takes
 	//! an optional io_service to construct the socket from.
 	ReceiverTcp( const protocol::endpoint &localEndpoint,
-				 asio::io_service &service = ci::app::App::get()->io_service(),
+				 asio::io_service &service = ci::app::App::get()->io_context(),
 				 PacketFramingRef packetFraming = nullptr );
 	//! Constructs a Receiver (called a \a client in the OSC spec) using TCP for transport, from the already
 	//! constructed tcp::acceptor shared_ptr \a acceptor and PacketFraming shared_ptr \a packetFraming, which

--- a/apps/Silversprints/include/data/SerialReader.h
+++ b/apps/Silversprints/include/data/SerialReader.h
@@ -71,7 +71,7 @@ namespace gfx
 		
 		std::string mStringBuffer;
 		std::string mFirmwareVersion;
-		std::string mConnectedPortName = "Arduino.*";
+		std::string mConnectedPortName = "/dev/ttyACM0";
 		double mLastKeepAlive = 0.0;
 		
 		// threading


### PR DESCRIPTION
WIP porting SilverSprints for Linux, since there was no makefiles available for such platform (CMake added) and a few code changes to compile against the bundled OSC library.
The Arduino comunicates fine with SilverSprints but some adjustments still need to be fixed specially regarding to UI misalingned widgets.

To compile, enter the Silversprints folder located at apps/ and create another folder called build/.
From within build folder, issue CMake to start building (you need to build libcinder by yourself):

```
$ cmake ../ -DCINDER_PATH=PATH_TO_YOUR_LIBCINDER_FODER
$ make

```


<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/e6c0a753-5cf8-45c0-ba5d-612695b6590f" />





<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/ffbc11db-7e2a-4d29-a238-15b976363e57" />

